### PR TITLE
fix: correct composed API endpoint paths

### DIFF
--- a/Services/AuditLogService.cs
+++ b/Services/AuditLogService.cs
@@ -144,19 +144,19 @@ namespace NginxProxyManager.SDK.Services
 
         public async Task DeleteAuditLogAsync(int auditLogId, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Delete, $"api/audit-logs/{auditLogId}");
+            using var request = CreateRequest(HttpMethod.Delete, auditLogId.ToString());
             await SendAsync<object>(request, cancellationToken);
         }
 
         public async Task DeleteAuditLogsByUserIdAsync(int userId, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Delete, $"api/audit-logs/user/{userId}");
+            using var request = CreateRequest(HttpMethod.Delete, $"user/{userId}");
             await SendAsync<object>(request, cancellationToken);
         }
 
         public async Task DeleteAuditLogsByDateRangeAsync(DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Delete, $"api/audit-logs/date-range?startDate={startDate:yyyy-MM-dd}&endDate={endDate:yyyy-MM-dd}");
+            using var request = CreateRequest(HttpMethod.Delete, $"date-range?startDate={startDate:yyyy-MM-dd}&endDate={endDate:yyyy-MM-dd}");
             await SendAsync<object>(request, cancellationToken);
         }
     }

--- a/Services/CertificateService.cs
+++ b/Services/CertificateService.cs
@@ -8,44 +8,44 @@ namespace NginxProxyManager.SDK.Services
 {
     public class CertificateService : NPMServiceBase, ICertificateService
     {
-        public CertificateService(HttpClient httpClient, string baseUrl)
-            : base(httpClient, baseUrl)
+        public CertificateService(HttpClient httpClient)
+            : base(httpClient, "api/certificates")
         {
         }
 
         public async Task<CertificateModel[]> GetCertificatesAsync(CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Get, "api/certificates");
+            using var request = CreateRequest(HttpMethod.Get, "");
             return await SendAsync<CertificateModel[]>(request, cancellationToken);
         }
 
         public async Task<CertificateModel> GetCertificateAsync(int certificateId, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Get, $"api/certificates/{certificateId}");
+            using var request = CreateRequest(HttpMethod.Get, certificateId.ToString());
             return await SendAsync<CertificateModel>(request, cancellationToken);
         }
 
         public async Task<CertificateModel> CreateCertificateAsync(CertificateCreateRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpRequest = CreateRequest(HttpMethod.Post, "api/certificates", request);
+            using var httpRequest = CreateRequest(HttpMethod.Post, "", request);
             return await SendAsync<CertificateModel>(httpRequest, cancellationToken);
         }
 
         public async Task<CertificateModel> UpdateCertificateAsync(int certificateId, CertificateUpdateRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpRequest = CreateRequest(HttpMethod.Put, $"api/certificates/{certificateId}", request);
+            using var httpRequest = CreateRequest(HttpMethod.Put, certificateId.ToString(), request);
             return await SendAsync<CertificateModel>(httpRequest, cancellationToken);
         }
 
         public async Task DeleteCertificateAsync(int certificateId, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Delete, $"api/certificates/{certificateId}");
+            using var request = CreateRequest(HttpMethod.Delete, certificateId.ToString());
             await SendAsync<object>(request, cancellationToken);
         }
 
         public async Task<CertificateModel> RenewCertificateAsync(int certificateId, CancellationToken cancellationToken = default)
         {
-            using var request = CreateRequest(HttpMethod.Post, $"api/certificates/{certificateId}/renew");
+            using var request = CreateRequest(HttpMethod.Post, $"{certificateId}/renew");
             return await SendAsync<CertificateModel>(request, cancellationToken);
         }
     }

--- a/Services/NPMServiceBase.cs
+++ b/Services/NPMServiceBase.cs
@@ -29,7 +29,10 @@ namespace NginxProxyManager.SDK.Services
 
         protected HttpRequestMessage CreateRequest(HttpMethod method, string path, object body = null)
         {
-            var request = new HttpRequestMessage(method, $"{_baseUrl}/{path}");
+            var requestUri = path?.StartsWith("/", StringComparison.Ordinal) == true
+                ? path.TrimStart('/')
+                : $"{_baseUrl}/{path}";
+            var request = new HttpRequestMessage(method, requestUri);
             request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
 
             if (body != null)

--- a/Services/RedirectionService.cs
+++ b/Services/RedirectionService.cs
@@ -98,7 +98,7 @@ namespace NginxProxyManager.SDK.Services
             try
             {
                 Debug.WriteLine($"Making GET request to: nginx/redirection-hosts");
-                var path = "nginx/redirection-hosts";
+                var path = "/api/nginx/redirection-hosts";
                 if (!string.IsNullOrEmpty(expand))
                 {
                     path += $"?expand={expand}";
@@ -121,7 +121,7 @@ namespace NginxProxyManager.SDK.Services
             try
             {
                 Debug.WriteLine($"Making GET request to: nginx/redirection-hosts/{hostId}");
-                using var request = CreateRequest(HttpMethod.Get, $"nginx/redirection-hosts/{hostId}");
+                using var request = CreateRequest(HttpMethod.Get, $"/api/nginx/redirection-hosts/{hostId}");
                 var response = await SendAsync<RedirectionHost>(request, cancellationToken);
                 return OperationResult<RedirectionHost>.Success(response);
             }
@@ -138,7 +138,7 @@ namespace NginxProxyManager.SDK.Services
             try
             {
                 Debug.WriteLine($"Making POST request to: nginx/redirection-hosts");
-                using var httpRequest = CreateRequest(HttpMethod.Post, "nginx/redirection-hosts", request);
+                using var httpRequest = CreateRequest(HttpMethod.Post, "/api/nginx/redirection-hosts", request);
                 var response = await SendAsync<RedirectionHost>(httpRequest, cancellationToken);
                 return OperationResult<RedirectionHost>.Success(response);
             }
@@ -155,7 +155,7 @@ namespace NginxProxyManager.SDK.Services
             try
             {
                 Debug.WriteLine($"Making PUT request to: nginx/redirection-hosts/{hostId}");
-                using var httpRequest = CreateRequest(HttpMethod.Put, $"nginx/redirection-hosts/{hostId}", request);
+                using var httpRequest = CreateRequest(HttpMethod.Put, $"/api/nginx/redirection-hosts/{hostId}", request);
                 var response = await SendAsync<RedirectionHost>(httpRequest, cancellationToken);
                 return OperationResult<RedirectionHost>.Success(response);
             }
@@ -172,7 +172,7 @@ namespace NginxProxyManager.SDK.Services
             try
             {
                 Debug.WriteLine($"Making DELETE request to: nginx/redirection-hosts/{hostId}");
-                using var request = CreateRequest(HttpMethod.Delete, $"nginx/redirection-hosts/{hostId}");
+                using var request = CreateRequest(HttpMethod.Delete, $"/api/nginx/redirection-hosts/{hostId}");
                 await SendAsync<object>(request, cancellationToken);
                 return OperationResult<bool>.Success(true);
             }


### PR DESCRIPTION
## Summary
Fixes #4.

## Changes
- Allows `NPMServiceBase.CreateRequest` to handle rooted API paths for services that need to call sibling API resources.
- Corrects redirection-host methods to call `api/nginx/redirection-hosts` instead of nesting them under `api/redirections`.
- Normalizes `CertificateService` around an `api/certificates` base path plus relative method paths.
- Fixes duplicate `api/audit-logs` path construction in audit-log delete helpers found during the same endpoint audit.

## Testing
- `dotnet build --no-restore` ✅ (passes; existing nullable warnings remain)
