### PR TITLE
fix: preserve resource layer failures

### DIFF
--- a/Resources/AccessListsResource.cs
+++ b/Resources/AccessListsResource.cs
@@ -43,8 +43,7 @@ namespace NginxProxyManager.SDK.Resources
         /// <inheritdoc />
         public async Task<OperationResult<IEnumerable<AccessList>>> GetAllAsync()
         {
-            var result = await _accessListService.GetAllAsync();
-            return new OperationResult<IEnumerable<AccessList>>(result.Result);
+            return await _accessListService.GetAllAsync();
         }
 
         /// <inheritdoc />

--- a/Resources/DeadHostsResource.cs
+++ b/Resources/DeadHostsResource.cs
@@ -44,7 +44,9 @@ namespace NginxProxyManager.SDK.Resources
         public async Task<OperationResult<IEnumerable<DeadHost>>> GetAllAsync()
         {
             var result = await _deadHostService.GetAllAsync();
-            return new OperationResult<IEnumerable<DeadHost>>(result.Result);
+            return result.IsSuccess
+                ? new OperationResult<IEnumerable<DeadHost>>(result.Result)
+                : new OperationResult<IEnumerable<DeadHost>>(result.Error);
         }
 
         /// <inheritdoc />

--- a/Resources/ProxyHostsResource.cs
+++ b/Resources/ProxyHostsResource.cs
@@ -44,7 +44,9 @@ namespace NginxProxyManager.SDK.Resources
         public async Task<OperationResult<IEnumerable<ProxyHost>>> GetAllAsync()
         {
             var result = await _proxyHostService.GetAllAsync();
-            return new OperationResult<IEnumerable<ProxyHost>>(result.Result);
+            return result.IsSuccess
+                ? new OperationResult<IEnumerable<ProxyHost>>(result.Result)
+                : new OperationResult<IEnumerable<ProxyHost>>(result.Error);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
Fixes #6.

## Changes
- Preserves failed `OperationResult` values in resource-level `GetAllAsync` wrappers instead of wrapping failed/null results as success.
- Simplifies access-list result forwarding where service/resource generic types already match.

## Testing
- `dotnet build --no-restore` ✅ (passes; existing nullable warnings remain)
