### PR TITLE
fix: clone requests before auth retry

### DIFF
--- a/Client/AuthenticationHandler.cs
+++ b/Client/AuthenticationHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NginxProxyManager.SDK.Services;
@@ -35,31 +36,30 @@ namespace NginxProxyManager.SDK.Client
         {
             Debug.WriteLine($"Processing request: {request.Method} {request.RequestUri}");
             
-            var retryCount = 0;
-            HttpResponseMessage response;
-
-            do
+            for (var retryCount = 0; retryCount <= MaxRetries; retryCount++)
             {
+                using var requestToSend = await CloneHttpRequestMessageAsync(request, cancellationToken);
+
                 if (!string.IsNullOrEmpty(_cachedToken))
                 {
                     Debug.WriteLine("Using cached token");
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _cachedToken);
+                    requestToSend.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _cachedToken);
                 }
                 else
                 {
                     Debug.WriteLine("No cached token, getting new token");
                     var token = await _authService.GetValidTokenAsync(_credentials);
                     _cachedToken = token;
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    requestToSend.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 }
 
-                response = await base.SendAsync(request, cancellationToken);
+                var response = await base.SendAsync(requestToSend, cancellationToken);
                 
                 if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized && retryCount < MaxRetries)
                 {
                     Debug.WriteLine("Received 401 Unauthorized, clearing token and retrying...");
+                    response.Dispose();
                     _cachedToken = null;
-                    retryCount++;
                     continue;
                 }
 
@@ -70,10 +70,44 @@ namespace NginxProxyManager.SDK.Client
                     Debug.WriteLine($"Response content: {content}");
                 }
                 
-                break;
-            } while (retryCount <= MaxRetries);
-            
-            return response;
+                return response;
+            }
+
+            throw new InvalidOperationException("Authentication retry loop completed without returning a response.");
+        }
+
+        private static async Task<HttpRequestMessage> CloneHttpRequestMessageAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Version = request.Version,
+                VersionPolicy = request.VersionPolicy
+            };
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            foreach (var option in request.Options)
+            {
+                clone.Options.TryAdd(option.Key, option.Value);
+            }
+
+            if (request.Content != null)
+            {
+                var stream = new MemoryStream();
+                await request.Content.CopyToAsync(stream, cancellationToken);
+                stream.Position = 0;
+                clone.Content = new StreamContent(stream);
+
+                foreach (var header in request.Content.Headers)
+                {
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return clone;
         }
     }
 } 


### PR DESCRIPTION
## Summary
Fixes #5.

## Changes
- Sends a fresh cloned `HttpRequestMessage` for each auth attempt instead of replaying the original sent request.
- Copies method, URI, version, headers, options, and buffered content into each clone.
- Disposes the unauthorized response before retrying with a refreshed token.

## Testing
- `dotnet build --no-restore` ✅ (passes; existing nullable warnings remain)
