### PR TITLE
feat: expose certificates resource

### DIFF
--- a/Client/NginxProxyManagerClient.cs
+++ b/Client/NginxProxyManagerClient.cs
@@ -61,6 +61,11 @@ namespace NginxProxyManager.SDK.Client
         public IStreamResource Streams { get; }
 
         /// <summary>
+        /// Gets the certificates resource
+        /// </summary>
+        public ICertificatesResource Certificates { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="NginxProxyManagerClient"/> class.
         /// </summary>
         /// <param name="baseUrl">The base URL of the Nginx Proxy Manager API</param>
@@ -79,6 +84,7 @@ namespace NginxProxyManager.SDK.Client
             var reportsService = new ReportsService(_httpClient);
             var serverErrorService = new ServerErrorService(_httpClient);
             var streamService = new StreamService(_httpClient);
+            var certificateService = new CertificateService(_httpClient, string.Empty);
 
             // Initialize resources
             ProxyHosts = new ProxyHostsResource(proxyHostService);
@@ -89,6 +95,7 @@ namespace NginxProxyManager.SDK.Client
             Reports = new ReportsResource(reportsService);
             ServerErrors = new ServerErrorResource(serverErrorService);
             Streams = new StreamResource(streamService);
+            Certificates = new CertificatesResource(certificateService);
         }
 
         /// <inheritdoc />

--- a/Resources/CertificateBuilder.cs
+++ b/Resources/CertificateBuilder.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NginxProxyManager.SDK.Common;
+using NginxProxyManager.SDK.Models.Certificates;
+using NginxProxyManager.SDK.Services.Interfaces;
+
+namespace NginxProxyManager.SDK.Resources
+{
+    /// <summary>
+    /// Implementation of the certificate builder.
+    /// </summary>
+    public class CertificateBuilder : ICertificateBuilder
+    {
+        private readonly ICertificateService _certificateService;
+        private readonly CertificateCreateRequest _request = new CertificateCreateRequest();
+        private int? _id;
+
+        public CertificateBuilder(ICertificateService certificateService)
+        {
+            _certificateService = certificateService;
+        }
+
+        public ICertificateBuilder WithId(int id) { _id = id; return this; }
+        public ICertificateBuilder WithProvider(string provider) { _request.Provider = provider; return this; }
+        public ICertificateBuilder WithNiceName(string niceName) { _request.NiceName = niceName; return this; }
+        public ICertificateBuilder WithDomainNames(params string[] domainNames) { _request.DomainNames = domainNames; return this; }
+        public ICertificateBuilder WithMeta(Dictionary<string, object> meta) { _request.Meta = meta; return this; }
+        public ICertificateBuilder WithCertificate(string certificate) { _request.Certificate = certificate; return this; }
+        public ICertificateBuilder WithKey(string key) { _request.CertificateKey = key; return this; }
+        public ICertificateBuilder WithIntermediateCertificate(string intermediateCertificate) { _request.IntermediateCertificate = intermediateCertificate; return this; }
+        public CertificateCreateRequest Build() => _request;
+
+        public async Task<OperationResult<CertificateModel>> BuildAndCreateAsync()
+        {
+            try { return new OperationResult<CertificateModel>(await _certificateService.CreateCertificateAsync(_request)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+
+        public async Task<OperationResult<CertificateModel>> BuildAndUpdateAsync()
+        {
+            if (!_id.HasValue) return new OperationResult<CertificateModel>(new InvalidOperationException("Certificate ID is required for update."));
+            var updateRequest = new CertificateUpdateRequest
+            {
+                NiceName = _request.NiceName,
+                DomainNames = _request.DomainNames,
+                Meta = _request.Meta,
+                Certificate = _request.Certificate,
+                CertificateKey = _request.CertificateKey,
+                IntermediateCertificate = _request.IntermediateCertificate
+            };
+            try { return new OperationResult<CertificateModel>(await _certificateService.UpdateCertificateAsync(_id.Value, updateRequest)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+    }
+}

--- a/Resources/CertificatesResource.cs
+++ b/Resources/CertificatesResource.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NginxProxyManager.SDK.Common;
+using NginxProxyManager.SDK.Models.Certificates;
+using NginxProxyManager.SDK.Services.Interfaces;
+
+namespace NginxProxyManager.SDK.Resources
+{
+    /// <summary>
+    /// Resource for managing certificates.
+    /// </summary>
+    public class CertificatesResource : ICertificatesResource
+    {
+        private readonly ICertificateService _certificateService;
+
+        public CertificatesResource(ICertificateService certificateService)
+        {
+            _certificateService = certificateService;
+        }
+
+        public ICertificateBuilder CreateBuilder() => new CertificateBuilder(_certificateService);
+
+        public async Task<OperationResult<CertificateModel>> GetAsync(int id) => await GetByIdAsync(id);
+
+        public async Task<OperationResult<CertificateModel>> GetByIdAsync(int id)
+        {
+            try { return new OperationResult<CertificateModel>(await _certificateService.GetCertificateAsync(id)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+
+        public async Task<OperationResult<IEnumerable<CertificateModel>>> GetAllAsync()
+        {
+            try { return new OperationResult<IEnumerable<CertificateModel>>(await _certificateService.GetCertificatesAsync()); }
+            catch (Exception ex) { return new OperationResult<IEnumerable<CertificateModel>>(ex); }
+        }
+
+        public Task<OperationResult<IEnumerable<CertificateModel>>> GetPageAsync(int page, int pageSize)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<OperationResult<CertificateModel>> CreateAsync(CertificateModel resource)
+        {
+            throw new NotImplementedException("Use CreateAsync(CertificateCreateRequest) instead.");
+        }
+
+        public async Task<OperationResult<CertificateModel>> CreateAsync(CertificateCreateRequest certificate)
+        {
+            try { return new OperationResult<CertificateModel>(await _certificateService.CreateCertificateAsync(certificate)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+
+        public Task<OperationResult<CertificateModel>> UpdateAsync(int id, CertificateModel resource)
+        {
+            throw new NotImplementedException("Use UpdateAsync(int, CertificateUpdateRequest) instead.");
+        }
+
+        public async Task<OperationResult<CertificateModel>> UpdateAsync(int id, CertificateUpdateRequest certificate)
+        {
+            try { return new OperationResult<CertificateModel>(await _certificateService.UpdateCertificateAsync(id, certificate)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+
+        public async Task<OperationResult<bool>> DeleteAsync(int id)
+        {
+            try { await _certificateService.DeleteCertificateAsync(id); return new OperationResult<bool>(true); }
+            catch (Exception ex) { return new OperationResult<bool>(ex); }
+        }
+
+        public async Task<OperationResult<CertificateModel>> RenewAsync(int id)
+        {
+            try { return new OperationResult<CertificateModel>(await _certificateService.RenewCertificateAsync(id)); }
+            catch (Exception ex) { return new OperationResult<CertificateModel>(ex); }
+        }
+    }
+}

--- a/Resources/ICertificateBuilder.cs
+++ b/Resources/ICertificateBuilder.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using NginxProxyManager.SDK.Common;
+using NginxProxyManager.SDK.Models.Certificates;
+
+namespace NginxProxyManager.SDK.Resources
+{
+    /// <summary>
+    /// Builder for certificate create and update requests.
+    /// </summary>
+    public interface ICertificateBuilder
+    {
+        ICertificateBuilder WithId(int id);
+        ICertificateBuilder WithProvider(string provider);
+        ICertificateBuilder WithNiceName(string niceName);
+        ICertificateBuilder WithDomainNames(params string[] domainNames);
+        ICertificateBuilder WithMeta(Dictionary<string, object> meta);
+        ICertificateBuilder WithCertificate(string certificate);
+        ICertificateBuilder WithKey(string key);
+        ICertificateBuilder WithIntermediateCertificate(string intermediateCertificate);
+        CertificateCreateRequest Build();
+        Task<OperationResult<CertificateModel>> BuildAndCreateAsync();
+        Task<OperationResult<CertificateModel>> BuildAndUpdateAsync();
+    }
+}

--- a/Resources/ICertificatesResource.cs
+++ b/Resources/ICertificatesResource.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NginxProxyManager.SDK.Common;
+using NginxProxyManager.SDK.Models.Certificates;
+
+namespace NginxProxyManager.SDK.Resources
+{
+    /// <summary>
+    /// Represents the certificates resource.
+    /// </summary>
+    public interface ICertificatesResource : IResourceCollection<CertificateModel>
+    {
+        ICertificateBuilder CreateBuilder();
+        Task<OperationResult<CertificateModel>> GetAsync(int id);
+        Task<OperationResult<CertificateModel>> CreateAsync(CertificateCreateRequest certificate);
+        Task<OperationResult<CertificateModel>> UpdateAsync(int id, CertificateUpdateRequest certificate);
+        Task<OperationResult<CertificateModel>> RenewAsync(int id);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #3.

## Changes
- Adds a public `ICertificatesResource` and `CertificatesResource` for certificate CRUD and renewal operations.
- Adds a `CertificateBuilder`/`ICertificateBuilder` for fluent certificate create/update request construction.
- Exposes `client.Certificates` from `NginxProxyManagerClient` and wires it to the existing `CertificateService`.

## Testing
- `dotnet build --no-restore` ✅ (passes; existing nullable warnings remain)

## Note
Endpoint path normalization for `CertificateService` is intentionally handled separately in #4 / PR #11 to keep this PR focused on the missing public resource surface.
