### PR TITLE
ci: add dotnet build test pack workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-test-pack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal
+
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release --output ./artifacts


### PR DESCRIPTION
## Summary
Part of #8.

## Changes
- Adds a GitHub Actions workflow for pull requests and pushes to `master`.
- Runs restore, Release build, test, and pack so future SDK changes get a baseline validation gate.

## Testing
- `dotnet build --no-restore` ✅ (passes; existing nullable warnings remain)

## Follow-up
This adds CI coverage. Meaningful request-behavior unit tests are still tracked in #8 as follow-up work because they require a larger test-project design.
