### PR TITLE
fix: restore certificate service build

### DIFF
--- a/Client/NginxProxyManagerClient.cs
+++ b/Client/NginxProxyManagerClient.cs
@@ -84,7 +84,7 @@ namespace NginxProxyManager.SDK.Client
             var reportsService = new ReportsService(_httpClient);
             var serverErrorService = new ServerErrorService(_httpClient);
             var streamService = new StreamService(_httpClient);
-            var certificateService = new CertificateService(_httpClient, string.Empty);
+            var certificateService = new CertificateService(_httpClient);
 
             // Initialize resources
             ProxyHosts = new ProxyHostsResource(proxyHostService);


### PR DESCRIPTION
Fixes a post-merge build break from the certificate resource wiring: `NginxProxyManagerClient` now constructs `CertificateService` with its current constructor.

Gates run locally:
- `dotnet restore` ✅
- `dotnet build --no-restore` ✅
- `dotnet pack` ✅

Part of #8.