### PR TITLE
test: add SDK request behavior coverage

### DIFF
--- a/NginxProxyManager.SDK.csproj
+++ b/NginxProxyManager.SDK.csproj
@@ -38,4 +38,8 @@
 	    <PackagePath>\</PackagePath>
 	  </None>
 	</ItemGroup>
+	<ItemGroup>
+	  <Compile Remove="tests/**/*.cs" />
+	  <None Remove="tests/**" />
+	</ItemGroup>
 </Project>

--- a/NginxProxyManager.SDK.slnx
+++ b/NginxProxyManager.SDK.slnx
@@ -1,0 +1,6 @@
+<Solution>
+  <Folder Name="/tests/">
+    <Project Path="tests/NginxProxyManager.SDK.Tests/NginxProxyManager.SDK.Tests.csproj" />
+  </Folder>
+  <Project Path="NginxProxyManager.SDK.csproj" />
+</Solution>

--- a/tests/NginxProxyManager.SDK.Tests/AuthenticationHandlerTests.cs
+++ b/tests/NginxProxyManager.SDK.Tests/AuthenticationHandlerTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using NginxProxyManager.SDK.Client;
+using NginxProxyManager.SDK.Services.Interfaces;
+using Xunit;
+
+namespace NginxProxyManager.SDK.Tests;
+
+public class AuthenticationHandlerTests
+{
+    [Fact]
+    public async Task SendAsync_AfterUnauthorizedRefreshesTokenAndRetriesWithClonedContent()
+    {
+        var terminal = new RecordingHttpMessageHandler(
+            req => new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("nope") },
+            req => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") });
+        var auth = new SequenceAuthService("stale-token", "fresh-token");
+        var client = new HttpClient(new AuthenticationHandler(auth, new AuthenticationCredentials("admin@example.com", "secret"))
+        {
+            InnerHandler = terminal
+        })
+        {
+            BaseAddress = new Uri("https://npm.example/")
+        };
+
+        using var response = await client.PostAsync("api/nginx/proxy-hosts", new StringContent("{\"hello\":\"world\"}"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, terminal.Requests.Count);
+        Assert.Equal("Bearer", terminal.Requests[0].Headers.Authorization!.Scheme);
+        Assert.Equal("stale-token", terminal.Requests[0].Headers.Authorization!.Parameter);
+        Assert.Equal("fresh-token", terminal.Requests[1].Headers.Authorization!.Parameter);
+        Assert.Equal("{\"hello\":\"world\"}", terminal.RequestBodies[0]);
+        Assert.Equal("{\"hello\":\"world\"}", terminal.RequestBodies[1]);
+        Assert.Equal(2, auth.GetValidTokenCallCount);
+    }
+
+    private sealed class SequenceAuthService : IAuthService
+    {
+        private readonly Queue<string> _tokens;
+        public int GetValidTokenCallCount { get; private set; }
+
+        public SequenceAuthService(params string[] tokens) => _tokens = new Queue<string>(tokens);
+        public Task<string> AuthenticateAsync(AuthenticationCredentials credentials) => GetValidTokenAsync(credentials);
+        public Task<string> GetValidTokenAsync(AuthenticationCredentials credentials)
+        {
+            GetValidTokenCallCount++;
+            return Task.FromResult(_tokens.Dequeue());
+        }
+    }
+}

--- a/tests/NginxProxyManager.SDK.Tests/HttpTestHelpers.cs
+++ b/tests/NginxProxyManager.SDK.Tests/HttpTestHelpers.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NginxProxyManager.SDK.Tests;
+
+internal sealed class RecordingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses;
+
+    public List<HttpRequestMessage> Requests { get; } = new();
+    public List<string?> RequestBodies { get; } = new();
+
+    public RecordingHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
+    {
+        _responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(responses);
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        RequestBodies.Add(request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken));
+
+        if (_responses.Count == 0)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+        }
+
+        return _responses.Dequeue()(request);
+    }
+}

--- a/tests/NginxProxyManager.SDK.Tests/NginxProxyManager.SDK.Tests.csproj
+++ b/tests/NginxProxyManager.SDK.Tests/NginxProxyManager.SDK.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../NginxProxyManager.SDK.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/NginxProxyManager.SDK.Tests/ProxyHostServiceTests.cs
+++ b/tests/NginxProxyManager.SDK.Tests/ProxyHostServiceTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Text.Json;
+using NginxProxyManager.SDK.Models.Proxies;
+using NginxProxyManager.SDK.Services;
+using Xunit;
+
+namespace NginxProxyManager.SDK.Tests;
+
+public class ProxyHostServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_PostsToProxyHostsWithExpectedJsonFields()
+    {
+        var handler = new RecordingHttpMessageHandler(_ => JsonResponse("{\"id\":42}"));
+        var service = new ProxyHostService(new HttpClient(handler) { BaseAddress = new Uri("https://npm.example/") });
+
+        var result = await service.CreateAsync(new ProxyHostCreateRequest
+        {
+            DomainNames = new[] { "app.example.com" },
+            ForwardHost = "10.0.0.10",
+            ForwardPort = 8080,
+            ForwardScheme = "http",
+            CertificateId = 1,
+            SslEnabled = true,
+            AdvancedConfig = string.Empty
+        });
+
+        Assert.True(result.IsSuccess);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("https://npm.example/api/nginx/proxy-hosts", request.RequestUri!.ToString());
+
+        using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies)!);
+        Assert.True(body.RootElement.TryGetProperty("domain_names", out _));
+        Assert.True(body.RootElement.TryGetProperty("forward_host", out _));
+        Assert.True(body.RootElement.TryGetProperty("forward_port", out _));
+        Assert.True(body.RootElement.TryGetProperty("forward_scheme", out _));
+        Assert.True(body.RootElement.TryGetProperty("certificate_id", out _));
+        Assert.True(body.RootElement.TryGetProperty("ssl_forced", out _));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UsesProxyHostIdRoute()
+    {
+        var handler = new RecordingHttpMessageHandler(_ => JsonResponse("{}"));
+        var service = new ProxyHostService(new HttpClient(handler) { BaseAddress = new Uri("https://npm.example/") });
+
+        var result = await service.DeleteAsync(123);
+
+        Assert.True(result.IsSuccess);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Delete, request.Method);
+        Assert.Equal("https://npm.example/api/nginx/proxy-hosts/123", request.RequestUri!.ToString());
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+    };
+}


### PR DESCRIPTION
Adds a real solution-level test project with fake `HttpMessageHandler` coverage for core SDK request behavior:

- verifies proxy-host create/delete routes and JSON body field names
- verifies auth retry refreshes the bearer token after 401 and resends a cloned request body
- excludes test sources from the packed SDK project
- adds `NginxProxyManager.SDK.slnx` so root `dotnet test` discovers tests in CI

Gates run locally:
- `dotnet restore NginxProxyManager.SDK.slnx` ✅
- `dotnet build NginxProxyManager.SDK.slnx --no-restore --configuration Release` ✅
- `dotnet test NginxProxyManager.SDK.slnx --no-build --configuration Release --verbosity normal` ✅ (3 passed)
- `dotnet pack NginxProxyManager.SDK.slnx --no-build --configuration Release --output ./artifacts` ✅

Part of #8.