### PR TITLE
fix: reduce nullable warning debt

### DIFF
--- a/Client/AuthenticationCredentials.cs
+++ b/Client/AuthenticationCredentials.cs
@@ -15,17 +15,17 @@ namespace NginxProxyManager.SDK.Client
         /// <summary>
         /// Gets the identity (email/username)
         /// </summary>
-        public string Identity { get; }
+        public string Identity { get; } = default!;
 
         /// <summary>
         /// Gets the secret (password)
         /// </summary>
-        public string Secret { get; }
+        public string Secret { get; } = default!;
 
         /// <summary>
         /// Gets the token (for token-based authentication)
         /// </summary>
-        public string Token { get; }
+        public string Token { get; } = default!;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationCredentials"/> class for token-based authentication

--- a/Client/AuthenticationHandler.cs
+++ b/Client/AuthenticationHandler.cs
@@ -17,7 +17,7 @@ namespace NginxProxyManager.SDK.Client
     {
         private readonly IAuthService _authService;
         private readonly AuthenticationCredentials _credentials;
-        private string _cachedToken;
+        private string? _cachedToken;
         private const int MaxRetries = 1;
 
         /// <summary>

--- a/Client/NginxProxyManagerClientConfig.cs
+++ b/Client/NginxProxyManagerClientConfig.cs
@@ -12,12 +12,12 @@ namespace NginxProxyManager.SDK.Client
         /// <summary>
         /// Gets or sets the base URL for the Nginx Proxy Manager API
         /// </summary>
-        public string BaseUrl { get; private set; }
+        public string BaseUrl { get; private set; } = default!;
 
         /// <summary>
         /// Gets or sets the authentication credentials
         /// </summary>
-        public AuthenticationCredentials Credentials { get; private set; }
+        public AuthenticationCredentials Credentials { get; private set; } = default!;
 
         /// <summary>
         /// Gets or sets the HTTP client timeout
@@ -32,12 +32,12 @@ namespace NginxProxyManager.SDK.Client
         /// <summary>
         /// Gets or sets the logger
         /// </summary>
-        public ILogger Logger { get; private set; }
+        public ILogger? Logger { get; private set; }
 
         /// <summary>
         /// Gets or sets the HTTP client
         /// </summary>
-        public HttpClient HttpClient { get; private set; }
+        public HttpClient? HttpClient { get; private set; }
 
         /// <summary>
         /// Sets the base URL for the Nginx Proxy Manager API

--- a/Common/OperationResult.cs
+++ b/Common/OperationResult.cs
@@ -16,18 +16,18 @@ namespace NginxProxyManager.SDK.Common
         /// <summary>
         /// Gets the result of the operation
         /// </summary>
-        public T Result { get; }
+        public T? Result { get; }
 
         /// <summary>
         /// Gets the error that occurred during the operation
         /// </summary>
-        public Exception Error { get; }
+        public Exception? Error { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OperationResult{T}"/> class with a successful result
         /// </summary>
         /// <param name="result">The result of the operation</param>
-        public OperationResult(T result)
+        public OperationResult(T? result)
         {
             IsSuccess = true;
             Result = result;
@@ -48,7 +48,7 @@ namespace NginxProxyManager.SDK.Common
         /// </summary>
         /// <param name="result">The result of the operation</param>
         /// <returns>A successful operation result</returns>
-        public static OperationResult<T> Success(T result)
+        public static OperationResult<T> Success(T? result)
         {
             return new OperationResult<T>(result);
         }

--- a/Configuration/NPMConfiguration.cs
+++ b/Configuration/NPMConfiguration.cs
@@ -7,17 +7,17 @@ namespace NginxProxyManager.SDK.Configuration
         /// <summary>
         /// The base URL of your Nginx Proxy Manager instance (e.g., "http://localhost:81")
         /// </summary>
-        public string BaseUrl { get; set; }
+        public string BaseUrl { get; set; } = default!;
 
         /// <summary>
         /// The email/username for authentication
         /// </summary>
-        public string Email { get; set; }
+        public string Email { get; set; } = default!;
 
         /// <summary>
         /// The password for authentication
         /// </summary>
-        public string Password { get; set; }
+        public string Password { get; set; } = default!;
 
         /// <summary>
         /// Optional timeout for HTTP requests in seconds (default: 30)

--- a/Models/AccessLists/AccessList.cs
+++ b/Models/AccessLists/AccessList.cs
@@ -9,6 +9,6 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         /// Owner user information
         /// </summary>
         [JsonPropertyName("owner")]
-        public User Owner { get; set; }
+        public User Owner { get; set; } = default!;
     }
 } 

--- a/Models/AccessLists/AccessListAuthItem.cs
+++ b/Models/AccessLists/AccessListAuthItem.cs
@@ -18,14 +18,14 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         [JsonPropertyName("username")]
         [Required]
         [MinLength(1)]
-        public string Username { get; set; }
+        public string Username { get; set; } = default!;
 
         /// <summary>
         /// Password for basic authentication (hashed)
         /// </summary>
         [JsonPropertyName("password")]
         [Required]
-        public string Password { get; set; }
+        public string Password { get; set; } = default!;
 
         /// <summary>
         /// Creation timestamp

--- a/Models/AccessLists/AccessListBase.cs
+++ b/Models/AccessLists/AccessListBase.cs
@@ -17,13 +17,13 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         [JsonPropertyName("name")]
         [Required]
         [MinLength(1)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Description of the access list
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Whether the access list is enabled
@@ -36,25 +36,25 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         /// </summary>
         [JsonPropertyName("satisfy")]
         [Required]
-        public string Satisfy { get; set; }
+        public string Satisfy { get; set; } = default!;
 
         /// <summary>
         /// IP addresses that are allowed/denied
         /// </summary>
         [JsonPropertyName("ip_addresses")]
-        public string IpAddresses { get; set; }
+        public string IpAddresses { get; set; } = default!;
 
         /// <summary>
         /// Basic authentication credentials
         /// </summary>
         [JsonPropertyName("basic_auth")]
-        public string BasicAuth { get; set; }
+        public string BasicAuth { get; set; } = default!;
 
         /// <summary>
         /// Whether to allow or deny access
         /// </summary>
         [JsonPropertyName("action")]
         [Required]
-        public string Action { get; set; }
+        public string Action { get; set; } = default!;
     }
 } 

--- a/Models/AccessLists/AccessListCreateRequest.cs
+++ b/Models/AccessLists/AccessListCreateRequest.cs
@@ -11,13 +11,13 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         [JsonPropertyName("name")]
         [Required]
         [MinLength(1)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Description of the access list
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Whether the access list is enabled
@@ -30,26 +30,26 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         /// </summary>
         [JsonPropertyName("satisfy")]
         [Required]
-        public string Satisfy { get; set; }
+        public string Satisfy { get; set; } = default!;
 
         /// <summary>
         /// IP addresses that are allowed/denied
         /// </summary>
         [JsonPropertyName("ip_addresses")]
-        public string IpAddresses { get; set; }
+        public string IpAddresses { get; set; } = default!;
 
         /// <summary>
         /// Basic authentication credentials
         /// </summary>
         [JsonPropertyName("basic_auth")]
-        public string BasicAuth { get; set; }
+        public string BasicAuth { get; set; } = default!;
 
         /// <summary>
         /// Whether to allow or deny access
         /// </summary>
         [JsonPropertyName("action")]
         [Required]
-        public string Action { get; set; }
+        public string Action { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata

--- a/Models/AccessLists/AccessListFull.cs
+++ b/Models/AccessLists/AccessListFull.cs
@@ -37,7 +37,7 @@ namespace NginxProxyManager.SDK.Models.AccessLists
         /// Owner user information
         /// </summary>
         [JsonPropertyName("owner")]
-        public User Owner { get; set; }
+        public User Owner { get; set; } = default!;
 
         /// <summary>
         /// Authentication items associated with this access list

--- a/Models/AccessLists/AccessListUpdateRequest.cs
+++ b/Models/AccessLists/AccessListUpdateRequest.cs
@@ -12,13 +12,13 @@ public class AccessListUpdateRequest
     [JsonPropertyName("name")]
     [Required]
     [MinLength(1)]
-    public string Name { get; set; }
+    public string Name { get; set; } = default!;
 
     /// <summary>
     /// Description of the access list
     /// </summary>
     [JsonPropertyName("description")]
-    public string Description { get; set; }
+    public string Description { get; set; } = default!;
 
     /// <summary>
     /// Whether the access list is enabled
@@ -31,26 +31,26 @@ public class AccessListUpdateRequest
     /// </summary>
     [JsonPropertyName("satisfy")]
     [Required]
-    public string Satisfy { get; set; }
+    public string Satisfy { get; set; } = default!;
 
     /// <summary>
     /// IP addresses that are allowed/denied
     /// </summary>
     [JsonPropertyName("ip_addresses")]
-    public string IpAddresses { get; set; }
+    public string IpAddresses { get; set; } = default!;
 
     /// <summary>
     /// Basic authentication credentials
     /// </summary>
     [JsonPropertyName("basic_auth")]
-    public string BasicAuth { get; set; }
+    public string BasicAuth { get; set; } = default!;
 
     /// <summary>
     /// Whether to allow or deny access
     /// </summary>
     [JsonPropertyName("action")]
     [Required]
-    public string Action { get; set; }
+    public string Action { get; set; } = default!;
 
     /// <summary>
     /// Additional metadata

--- a/Models/AuditLogs/AuditLog.cs
+++ b/Models/AuditLogs/AuditLog.cs
@@ -44,7 +44,7 @@ namespace NginxProxyManager.SDK.Models.AuditLogs
         /// </summary>
         [JsonPropertyName("object_type")]
         [Required]
-        public string ObjectType { get; set; }
+        public string ObjectType { get; set; } = default!;
 
         /// <summary>
         /// ID of the object that was affected
@@ -59,19 +59,19 @@ namespace NginxProxyManager.SDK.Models.AuditLogs
         /// </summary>
         [JsonPropertyName("action")]
         [Required]
-        public string Action { get; set; }
+        public string Action { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata about the audit log entry
         /// </summary>
         [JsonPropertyName("meta")]
         [Required]
-        public object Meta { get; set; }
+        public object Meta { get; set; } = default!;
 
         /// <summary>
         /// User information
         /// </summary>
         [JsonPropertyName("user")]
-        public User User { get; set; }
+        public User User { get; set; } = default!;
     }
 } 

--- a/Models/Auth/TokenRequest.cs
+++ b/Models/Auth/TokenRequest.cs
@@ -11,12 +11,12 @@ namespace NginxProxyManager.SDK.Models.Auth
         /// Gets or sets the identity (email/username)
         /// </summary>
         [JsonPropertyName("identity")]
-        public string Identity { get; set; }
+        public string Identity { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the secret (password)
         /// </summary>
         [JsonPropertyName("secret")]
-        public string Secret { get; set; }
+        public string Secret { get; set; } = default!;
     }
 } 

--- a/Models/Auth/TokenResponse.cs
+++ b/Models/Auth/TokenResponse.cs
@@ -12,7 +12,7 @@ namespace NginxProxyManager.SDK.Models.Auth
         /// Gets or sets the JWT token
         /// </summary>
         [JsonPropertyName("token")]
-        public string Token { get; set; }
+        public string Token { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the token expiration time

--- a/Models/Certificates/Certificate.cs
+++ b/Models/Certificates/Certificate.cs
@@ -18,14 +18,14 @@ namespace NginxProxyManager.SDK.Models.Certificates
         /// </summary>
         [JsonPropertyName("created_on")]
         [Required]
-        public string CreatedOn { get; set; }
+        public string CreatedOn { get; set; } = default!;
 
         /// <summary>
         /// Date and time of last update
         /// </summary>
         [JsonPropertyName("modified_on")]
         [Required]
-        public string ModifiedOn { get; set; }
+        public string ModifiedOn { get; set; } = default!;
 
         /// <summary>
         /// User ID of the owner
@@ -40,28 +40,28 @@ namespace NginxProxyManager.SDK.Models.Certificates
         [JsonPropertyName("provider")]
         [Required]
         [RegularExpression("^(letsencrypt|other)$")]
-        public string Provider { get; set; }
+        public string Provider { get; set; } = default!;
 
         /// <summary>
         /// Nice name for the certificate
         /// </summary>
         [JsonPropertyName("nice_name")]
         [Required]
-        public string NiceName { get; set; }
+        public string NiceName { get; set; } = default!;
 
         /// <summary>
         /// Domain names for the certificate
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Expiration date
         /// </summary>
         [JsonPropertyName("expires_on")]
         [Required]
-        public string ExpiresOn { get; set; }
+        public string ExpiresOn { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata

--- a/Models/Certificates/CertificateCreateRequest.cs
+++ b/Models/Certificates/CertificateCreateRequest.cs
@@ -11,21 +11,21 @@ namespace NginxProxyManager.SDK.Models.Certificates
         [JsonPropertyName("provider")]
         [Required]
         [RegularExpression("^(letsencrypt|other)$")]
-        public string Provider { get; set; }
+        public string Provider { get; set; } = default!;
 
         /// <summary>
         /// Nice name for the certificate
         /// </summary>
         [JsonPropertyName("nice_name")]
         [Required]
-        public string NiceName { get; set; }
+        public string NiceName { get; set; } = default!;
 
         /// <summary>
         /// Domain names for the certificate
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata
@@ -38,18 +38,18 @@ namespace NginxProxyManager.SDK.Models.Certificates
         /// Certificate key (for custom certificates)
         /// </summary>
         [JsonPropertyName("certificate_key")]
-        public string CertificateKey { get; set; }
+        public string CertificateKey { get; set; } = default!;
 
         /// <summary>
         /// Certificate (for custom certificates)
         /// </summary>
         [JsonPropertyName("certificate")]
-        public string Certificate { get; set; }
+        public string Certificate { get; set; } = default!;
 
         /// <summary>
         /// Intermediate certificate (for custom certificates)
         /// </summary>
         [JsonPropertyName("intermediate_certificate")]
-        public string IntermediateCertificate { get; set; }
+        public string IntermediateCertificate { get; set; } = default!;
     }
 } 

--- a/Models/Certificates/CertificateUpdateRequest.cs
+++ b/Models/Certificates/CertificateUpdateRequest.cs
@@ -9,36 +9,36 @@ namespace NginxProxyManager.SDK.Models.Certificates
         /// Nice name for the certificate
         /// </summary>
         [JsonPropertyName("nice_name")]
-        public string NiceName { get; set; }
+        public string NiceName { get; set; } = default!;
 
         /// <summary>
         /// Domain names for the certificate
         /// </summary>
         [JsonPropertyName("domain_names")]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata
         /// </summary>
         [JsonPropertyName("meta")]
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Meta { get; set; } = default!;
 
         /// <summary>
         /// Certificate key (for custom certificates)
         /// </summary>
         [JsonPropertyName("certificate_key")]
-        public string CertificateKey { get; set; }
+        public string CertificateKey { get; set; } = default!;
 
         /// <summary>
         /// Certificate (for custom certificates)
         /// </summary>
         [JsonPropertyName("certificate")]
-        public string Certificate { get; set; }
+        public string Certificate { get; set; } = default!;
 
         /// <summary>
         /// Intermediate certificate (for custom certificates)
         /// </summary>
         [JsonPropertyName("intermediate_certificate")]
-        public string IntermediateCertificate { get; set; }
+        public string IntermediateCertificate { get; set; } = default!;
     }
 } 

--- a/Models/Certificates/CertificateValidationResponse.cs
+++ b/Models/Certificates/CertificateValidationResponse.cs
@@ -3,7 +3,7 @@ namespace NginxProxyManager.SDK.Models.Certificates
     public class CertificateValidationResponse
     {
         public bool IsValid { get; set; }
-        public string Message { get; set; }
-        public string[] Errors { get; set; }
+        public string Message { get; set; } = default!;
+        public string[] Errors { get; set; } = default!;
     }
 } 

--- a/Models/Common/Result.cs
+++ b/Models/Common/Result.cs
@@ -6,11 +6,11 @@ namespace NginxProxyManager.SDK.Models.Common
     public class Result<T>
     {
         public bool IsSuccess { get; }
-        public T Data { get; }
-        public string Error { get; }
-        public Dictionary<string, string[]> ValidationErrors { get; }
+        public T? Data { get; }
+        public string? Error { get; }
+        public Dictionary<string, string[]>? ValidationErrors { get; }
 
-        private Result(bool isSuccess, T data, string error = null, Dictionary<string, string[]> validationErrors = null)
+        private Result(bool isSuccess, T? data, string? error = null, Dictionary<string, string[]>? validationErrors = null)
         {
             IsSuccess = isSuccess;
             Data = data;

--- a/Models/DeadHosts/CreateDeadHostRequest.cs
+++ b/Models/DeadHosts/CreateDeadHostRequest.cs
@@ -12,7 +12,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         [Required]
         [MinLength(1)]
         [MaxLength(100)]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID
@@ -49,7 +49,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Is Enabled
@@ -61,6 +61,6 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// Meta information
         /// </summary>
         [JsonPropertyName("meta")]
-        public object Meta { get; set; }
+        public object Meta { get; set; } = default!;
     }
 } 

--- a/Models/DeadHosts/DeadHost.cs
+++ b/Models/DeadHosts/DeadHost.cs
@@ -41,7 +41,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID
@@ -83,7 +83,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// </summary>
         [JsonPropertyName("advanced_config")]
         [Required]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Is Enabled
@@ -97,18 +97,18 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// </summary>
         [JsonPropertyName("meta")]
         [Required]
-        public object Meta { get; set; }
+        public object Meta { get; set; } = default!;
 
         /// <summary>
         /// Owner information
         /// </summary>
         [JsonPropertyName("owner")]
-        public User Owner { get; set; }
+        public User Owner { get; set; } = default!;
 
         /// <summary>
         /// Certificate information
         /// </summary>
         [JsonPropertyName("certificate")]
-        public object Certificate { get; set; }
+        public object Certificate { get; set; } = default!;
     }
 } 

--- a/Models/DeadHosts/UpdateDeadHostRequest.cs
+++ b/Models/DeadHosts/UpdateDeadHostRequest.cs
@@ -11,7 +11,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         [JsonPropertyName("domain_names")]
         [MinLength(1)]
         [MaxLength(100)]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID
@@ -47,7 +47,7 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Is Enabled
@@ -59,6 +59,6 @@ namespace NginxProxyManager.SDK.Models.DeadHosts
         /// Meta information
         /// </summary>
         [JsonPropertyName("meta")]
-        public object Meta { get; set; }
+        public object Meta { get; set; } = default!;
     }
 } 

--- a/Models/Proxies/ProxyHost.cs
+++ b/Models/Proxies/ProxyHost.cs
@@ -18,13 +18,13 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Date and time of creation
         /// </summary>
         [JsonPropertyName("created_on")]
-        public string CreatedOn { get; set; }
+        public string CreatedOn { get; set; } = default!;
 
         /// <summary>
         /// Date and time of last update
         /// </summary>
         [JsonPropertyName("modified_on")]
-        public string ModifiedOn { get; set; }
+        public string ModifiedOn { get; set; } = default!;
 
         /// <summary>
         /// User ID of the owner
@@ -36,13 +36,13 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Domain names for the proxy host
         /// </summary>
         [JsonPropertyName("domain_names")]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port
@@ -54,7 +54,7 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Forward scheme (http, https)
         /// </summary>
         [JsonPropertyName("forward_scheme")]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Whether the proxy host is enabled
@@ -96,30 +96,30 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Additional metadata
         /// </summary>
         [JsonPropertyName("meta")]
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Meta { get; set; } = default!;
 
         /// <summary>
         /// Associated certificate
         /// </summary>
         [JsonPropertyName("certificate")]
-        public CertificateModel Certificate { get; set; }
+        public CertificateModel Certificate { get; set; } = default!;
 
         /// <summary>
         /// Associated access list
         /// </summary>
         [JsonPropertyName("access_list")]
-        public AccessList AccessList { get; set; }
+        public AccessList AccessList { get; set; } = default!;
 
         /// <summary>
         /// Owner user information
         /// </summary>
         [JsonPropertyName("owner")]
-        public User Owner { get; set; }
+        public User Owner { get; set; } = default!;
     }
 } 

--- a/Models/Proxies/ProxyHostCreateRequest.cs
+++ b/Models/Proxies/ProxyHostCreateRequest.cs
@@ -14,14 +14,14 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
         [Required]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the forward port
@@ -37,7 +37,7 @@ namespace NginxProxyManager.SDK.Models.Proxies
         [JsonPropertyName("forward_scheme")]
         [Required]
         [RegularExpression("^(http|https)$")]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets whether SSL is enabled
@@ -73,7 +73,7 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Gets or sets the advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the certificate ID

--- a/Models/Proxies/ProxyHostUpdateRequest.cs
+++ b/Models/Proxies/ProxyHostUpdateRequest.cs
@@ -13,14 +13,14 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
         [Required]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the forward port
@@ -36,7 +36,7 @@ namespace NginxProxyManager.SDK.Models.Proxies
         [JsonPropertyName("forward_scheme")]
         [Required]
         [RegularExpression("^(http|https)$")]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets whether SSL is forced
@@ -78,7 +78,7 @@ namespace NginxProxyManager.SDK.Models.Proxies
         /// Gets or sets the advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the certificate ID

--- a/Models/Redirections/Redirection.cs
+++ b/Models/Redirections/Redirection.cs
@@ -39,6 +39,6 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// Owner user information
         /// </summary>
         [JsonPropertyName("owner")]
-        public User Owner { get; set; }
+        public User Owner { get; set; } = default!;
     }
 } 

--- a/Models/Redirections/RedirectionBase.cs
+++ b/Models/Redirections/RedirectionBase.cs
@@ -17,13 +17,13 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("name")]
         [Required]
         [MinLength(1)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Description of the redirection
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Whether the redirection is enabled
@@ -36,21 +36,21 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward scheme (http, https)
         /// </summary>
         [JsonPropertyName("forward_scheme")]
         [Required]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
         [Required]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port
@@ -100,7 +100,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID

--- a/Models/Redirections/RedirectionCreateRequest.cs
+++ b/Models/Redirections/RedirectionCreateRequest.cs
@@ -11,13 +11,13 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("name")]
         [Required]
         [MinLength(1)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Description of the redirection
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Whether the redirection is enabled
@@ -30,21 +30,21 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward scheme (http, https)
         /// </summary>
         [JsonPropertyName("forward_scheme")]
         [Required]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
         [Required]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port
@@ -94,7 +94,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID

--- a/Models/Redirections/RedirectionHost.cs
+++ b/Models/Redirections/RedirectionHost.cs
@@ -20,14 +20,14 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("created_on")]
         [Required]
-        public string CreatedOn { get; set; }
+        public string CreatedOn { get; set; } = default!;
 
         /// <summary>
         /// Date and time of last update
         /// </summary>
         [JsonPropertyName("modified_on")]
         [Required]
-        public string ModifiedOn { get; set; }
+        public string ModifiedOn { get; set; } = default!;
 
         /// <summary>
         /// User ID of the owner
@@ -41,7 +41,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward HTTP status code (300-308)
@@ -57,7 +57,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("forward_scheme")]
         [Required]
         [RegularExpression("^(auto|http|https)$")]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Forward domain name
@@ -65,7 +65,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("forward_domain_name")]
         [Required]
         [RegularExpression("^(?:[^.*]+\\.?)+[^.]$")]
-        public string ForwardDomainName { get; set; }
+        public string ForwardDomainName { get; set; } = default!;
 
         /// <summary>
         /// Whether to preserve the path when redirecting
@@ -121,7 +121,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("advanced_config")]
         [Required]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Whether the redirection host is enabled
@@ -135,18 +135,18 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("meta")]
         [Required]
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Meta { get; set; } = default!;
 
         /// <summary>
         /// Associated certificate
         /// </summary>
         [JsonPropertyName("certificate")]
-        public CertificateModel Certificate { get; set; }
+        public CertificateModel Certificate { get; set; } = default!;
 
         /// <summary>
         /// Associated access list
         /// </summary>
         [JsonPropertyName("access_list")]
-        public AccessList AccessList { get; set; }
+        public AccessList AccessList { get; set; } = default!;
     }
 } 

--- a/Models/Redirections/RedirectionHostCreateRequest.cs
+++ b/Models/Redirections/RedirectionHostCreateRequest.cs
@@ -10,7 +10,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward HTTP status code (300-308)
@@ -26,7 +26,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("forward_scheme")]
         [Required]
         [RegularExpression("^(auto|http|https)$")]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Forward domain name
@@ -34,7 +34,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("forward_domain_name")]
         [Required]
         [RegularExpression("^(?:[^.*]+\\.?)+[^.]$")]
-        public string ForwardDomainName { get; set; }
+        public string ForwardDomainName { get; set; } = default!;
 
         /// <summary>
         /// Whether to preserve the path when redirecting
@@ -89,7 +89,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("advanced_config")]
         [Required]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Whether the redirection host is enabled
@@ -103,6 +103,6 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("meta")]
         [Required]
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Meta { get; set; } = default!;
     }
 } 

--- a/Models/Redirections/RedirectionUpdateRequest.cs
+++ b/Models/Redirections/RedirectionUpdateRequest.cs
@@ -11,13 +11,13 @@ namespace NginxProxyManager.SDK.Models.Redirections
         [JsonPropertyName("name")]
         [Required]
         [MinLength(1)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Description of the redirection
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Whether the redirection is enabled
@@ -30,21 +30,21 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// </summary>
         [JsonPropertyName("domain_names")]
         [Required]
-        public string[] DomainNames { get; set; }
+        public string[] DomainNames { get; set; } = default!;
 
         /// <summary>
         /// Forward scheme (http, https)
         /// </summary>
         [JsonPropertyName("forward_scheme")]
         [Required]
-        public string ForwardScheme { get; set; }
+        public string ForwardScheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host
         /// </summary>
         [JsonPropertyName("forward_host")]
         [Required]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port
@@ -94,7 +94,7 @@ namespace NginxProxyManager.SDK.Models.Redirections
         /// Advanced configuration
         /// </summary>
         [JsonPropertyName("advanced_config")]
-        public string AdvancedConfig { get; set; }
+        public string AdvancedConfig { get; set; } = default!;
 
         /// <summary>
         /// Certificate ID

--- a/Models/ServerErrors/ServerError.cs
+++ b/Models/ServerErrors/ServerError.cs
@@ -28,7 +28,7 @@ namespace NginxProxyManager.SDK.Models.ServerErrors
         [JsonPropertyName("host_name")]
         [Required]
         [StringLength(255)]
-        public string HostName { get; set; }
+        public string HostName { get; set; } = default!;
 
         /// <summary>
         /// HTTP error code
@@ -44,7 +44,7 @@ namespace NginxProxyManager.SDK.Models.ServerErrors
         [JsonPropertyName("error_message")]
         [Required]
         [StringLength(1000)]
-        public string ErrorMessage { get; set; }
+        public string ErrorMessage { get; set; } = default!;
 
         /// <summary>
         /// URL of the request that caused the error
@@ -52,7 +52,7 @@ namespace NginxProxyManager.SDK.Models.ServerErrors
         [JsonPropertyName("request_url")]
         [Required]
         [StringLength(2048)]
-        public string RequestUrl { get; set; }
+        public string RequestUrl { get; set; } = default!;
 
         /// <summary>
         /// HTTP method of the request
@@ -60,35 +60,35 @@ namespace NginxProxyManager.SDK.Models.ServerErrors
         [JsonPropertyName("request_method")]
         [Required]
         [RegularExpression("^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)$")]
-        public string RequestMethod { get; set; }
+        public string RequestMethod { get; set; } = default!;
 
         /// <summary>
         /// Headers of the request
         /// </summary>
         [JsonPropertyName("request_headers")]
         [StringLength(4000)]
-        public string RequestHeaders { get; set; }
+        public string RequestHeaders { get; set; } = default!;
 
         /// <summary>
         /// Body of the request
         /// </summary>
         [JsonPropertyName("request_body")]
         [StringLength(10000)]
-        public string RequestBody { get; set; }
+        public string RequestBody { get; set; } = default!;
 
         /// <summary>
         /// Headers of the response
         /// </summary>
         [JsonPropertyName("response_headers")]
         [StringLength(4000)]
-        public string ResponseHeaders { get; set; }
+        public string ResponseHeaders { get; set; } = default!;
 
         /// <summary>
         /// Body of the response
         /// </summary>
         [JsonPropertyName("response_body")]
         [StringLength(10000)]
-        public string ResponseBody { get; set; }
+        public string ResponseBody { get; set; } = default!;
 
         /// <summary>
         /// Date and time when the error occurred

--- a/Models/Streams/CreateStreamRequest.cs
+++ b/Models/Streams/CreateStreamRequest.cs
@@ -11,7 +11,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("name")]
         [Required]
         [StringLength(255)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Stream scheme (tcp, udp)
@@ -19,7 +19,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("scheme")]
         [Required]
         [RegularExpression("^(tcp|udp)$")]
-        public string Scheme { get; set; }
+        public string Scheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host for the stream
@@ -27,7 +27,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("forward_host")]
         [Required]
         [RegularExpression("^(?:[^.*]+\\.?)+[^.]$")]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port for the stream

--- a/Models/Streams/Stream.cs
+++ b/Models/Streams/Stream.cs
@@ -47,7 +47,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         /// </summary>
         [JsonPropertyName("forwarding_host")]
         [Required]
-        public string ForwardingHost { get; set; }
+        public string ForwardingHost { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the forwarding port
@@ -88,7 +88,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         /// Gets or sets the metadata
         /// </summary>
         [JsonPropertyName("meta")]
-        public StreamMeta Meta { get; set; }
+        public StreamMeta Meta { get; set; } = default!;
     }
 
     /// <summary>
@@ -106,6 +106,6 @@ namespace NginxProxyManager.SDK.Models.Streams
         /// Gets or sets any Nginx errors
         /// </summary>
         [JsonPropertyName("nginx_err")]
-        public string NginxError { get; set; }
+        public string? NginxError { get; set; }
     }
 } 

--- a/Models/Streams/StreamModel.cs
+++ b/Models/Streams/StreamModel.cs
@@ -20,7 +20,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("name")]
         [Required]
         [StringLength(255)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Stream scheme (tcp, udp)
@@ -28,7 +28,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("scheme")]
         [Required]
         [RegularExpression("^(tcp|udp)$")]
-        public string Scheme { get; set; }
+        public string Scheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host for the stream
@@ -36,7 +36,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("forward_host")]
         [Required]
         [RegularExpression("^(?:[^.*]+\\.?)+[^.]$")]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port for the stream

--- a/Models/Streams/UpdateStreamRequest.cs
+++ b/Models/Streams/UpdateStreamRequest.cs
@@ -11,7 +11,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("name")]
         [Required]
         [StringLength(255)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Stream scheme (tcp, udp)
@@ -19,7 +19,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("scheme")]
         [Required]
         [RegularExpression("^(tcp|udp)$")]
-        public string Scheme { get; set; }
+        public string Scheme { get; set; } = default!;
 
         /// <summary>
         /// Forward host for the stream
@@ -27,7 +27,7 @@ namespace NginxProxyManager.SDK.Models.Streams
         [JsonPropertyName("forward_host")]
         [Required]
         [RegularExpression("^(?:[^.*]+\\.?)+[^.]$")]
-        public string ForwardHost { get; set; }
+        public string ForwardHost { get; set; } = default!;
 
         /// <summary>
         /// Forward port for the stream

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -12,12 +12,12 @@ namespace NginxProxyManager.SDK.Models
         /// <summary>
         /// Username
         /// </summary>
-        public string Username { get; set; }
+        public string Username { get; set; } = default!;
 
         /// <summary>
         /// Email address
         /// </summary>
-        public string Email { get; set; }
+        public string Email { get; set; } = default!;
 
         /// <summary>
         /// Whether the user is an administrator
@@ -27,11 +27,11 @@ namespace NginxProxyManager.SDK.Models
         /// <summary>
         /// Date and time of creation
         /// </summary>
-        public string CreatedOn { get; set; }
+        public string CreatedOn { get; set; } = default!;
 
         /// <summary>
         /// Date and time of last update
         /// </summary>
-        public string ModifiedOn { get; set; }
+        public string ModifiedOn { get; set; } = default!;
     }
 } 

--- a/Resources/DeadHostsResource.cs
+++ b/Resources/DeadHostsResource.cs
@@ -46,7 +46,7 @@ namespace NginxProxyManager.SDK.Resources
             var result = await _deadHostService.GetAllAsync();
             return result.IsSuccess
                 ? new OperationResult<IEnumerable<DeadHost>>(result.Result)
-                : new OperationResult<IEnumerable<DeadHost>>(result.Error);
+                : new OperationResult<IEnumerable<DeadHost>>(result.Error!);
         }
 
         /// <inheritdoc />

--- a/Resources/IProxyHostsResource.cs
+++ b/Resources/IProxyHostsResource.cs
@@ -27,7 +27,7 @@ namespace NginxProxyManager.SDK.Resources
         /// Gets all proxy hosts
         /// </summary>
         /// <returns>The operation result containing the proxy hosts</returns>
-        Task<OperationResult<IEnumerable<ProxyHost>>> GetAllAsync();
+        new Task<OperationResult<IEnumerable<ProxyHost>>> GetAllAsync();
 
         /// <summary>
         /// Gets a page of proxy hosts
@@ -35,7 +35,7 @@ namespace NginxProxyManager.SDK.Resources
         /// <param name="page">The page number</param>
         /// <param name="pageSize">The page size</param>
         /// <returns>The operation result containing the proxy hosts</returns>
-        Task<OperationResult<IEnumerable<ProxyHost>>> GetPageAsync(int page, int pageSize);
+        new Task<OperationResult<IEnumerable<ProxyHost>>> GetPageAsync(int page, int pageSize);
 
         /// <summary>
         /// Creates a new proxy host
@@ -57,7 +57,7 @@ namespace NginxProxyManager.SDK.Resources
         /// </summary>
         /// <param name="id">The proxy host ID</param>
         /// <returns>The operation result</returns>
-        Task<OperationResult<bool>> DeleteAsync(int id);
+        new Task<OperationResult<bool>> DeleteAsync(int id);
 
         /// <summary>
         /// Gets proxy hosts with SSL enabled

--- a/Resources/Interfaces/IStreamResource.cs
+++ b/Resources/Interfaces/IStreamResource.cs
@@ -16,7 +16,7 @@ namespace NginxProxyManager.SDK.Resources.Interfaces
         /// <param name="expand">Optional expansion parameter</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The operation result containing the streams</returns>
-        Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetAllAsync(string expand = null, CancellationToken cancellationToken = default);
+        Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetAllAsync(string? expand = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a stream by ID

--- a/Resources/ProxyHostsResource.cs
+++ b/Resources/ProxyHostsResource.cs
@@ -46,7 +46,7 @@ namespace NginxProxyManager.SDK.Resources
             var result = await _proxyHostService.GetAllAsync();
             return result.IsSuccess
                 ? new OperationResult<IEnumerable<ProxyHost>>(result.Result)
-                : new OperationResult<IEnumerable<ProxyHost>>(result.Error);
+                : new OperationResult<IEnumerable<ProxyHost>>(result.Error!);
         }
 
         /// <inheritdoc />

--- a/Resources/StreamResource.cs
+++ b/Resources/StreamResource.cs
@@ -25,7 +25,7 @@ namespace NginxProxyManager.SDK.Resources
         }
 
         /// <inheritdoc/>
-        public Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetAllAsync(string expand = null, CancellationToken cancellationToken = default)
+        public Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetAllAsync(string? expand = null, CancellationToken cancellationToken = default)
         {
             return _streamService.GetStreamsAsync(expand, cancellationToken);
         }

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -17,7 +17,7 @@ namespace NginxProxyManager.SDK.Services
     {
         private readonly HttpClient _httpClient;
         private readonly JsonSerializerOptions _jsonOptions;
-        private string _cachedToken;
+        private string? _cachedToken;
         private DateTime _tokenExpiration;
         private static readonly TimeSpan _refreshBuffer = TimeSpan.FromMinutes(5);
 
@@ -56,7 +56,8 @@ namespace NginxProxyManager.SDK.Services
                     throw new System.Net.Http.HttpRequestException($"Authentication failed: {response.StatusCode} - {error}");
                 }
 
-                var result = await response.Content.ReadFromJsonAsync<TokenResponse>(_jsonOptions);
+                var result = await response.Content.ReadFromJsonAsync<TokenResponse>(_jsonOptions)
+                    ?? throw new JsonException("Unable to deserialize authentication response.");
                 _cachedToken = result.Token;
                 _tokenExpiration = result.Expires;
                 Debug.WriteLine($"Authentication successful, token obtained. Expires at: {_tokenExpiration}");

--- a/Services/Interfaces/IRedirectionService.cs
+++ b/Services/Interfaces/IRedirectionService.cs
@@ -81,7 +81,7 @@ namespace NginxProxyManager.SDK.Services.Interfaces
         /// <param name="expand">The expansion parameter</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The operation result containing the redirection hosts</returns>
-        Task<OperationResult<RedirectionHost[]>> GetRedirectionHostsAsync(string expand, CancellationToken cancellationToken);
+        Task<OperationResult<RedirectionHost[]>> GetRedirectionHostsAsync(string? expand, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets a redirection host by ID

--- a/Services/Interfaces/IStreamService.cs
+++ b/Services/Interfaces/IStreamService.cs
@@ -16,7 +16,7 @@ namespace NginxProxyManager.SDK.Services.Interfaces
         /// <param name="expand">Optional expansion parameter</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The operation result containing the streams</returns>
-        Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetStreamsAsync(string expand = null, CancellationToken cancellationToken = default);
+        Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetStreamsAsync(string? expand = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a stream by ID

--- a/Services/NPMServiceBase.cs
+++ b/Services/NPMServiceBase.cs
@@ -21,13 +21,14 @@ namespace NginxProxyManager.SDK.Services
 
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<T>(content);
+                return JsonConvert.DeserializeObject<T>(content)
+                    ?? throw new JsonException($"Unable to deserialize response as {typeof(T).Name}.");
             }
 
             throw new HttpRequestException($"Error: {response.StatusCode} - {content}");
         }
 
-        protected HttpRequestMessage CreateRequest(HttpMethod method, string path, object body = null)
+        protected HttpRequestMessage CreateRequest(HttpMethod method, string path, object? body = null)
         {
             var requestUri = path?.StartsWith("/", StringComparison.Ordinal) == true
                 ? path.TrimStart('/')

--- a/Services/ProxyHostService.cs
+++ b/Services/ProxyHostService.cs
@@ -124,7 +124,7 @@ namespace NginxProxyManager.SDK.Services
             response.EnsureSuccessStatusCode();
 
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProxyHost>(responseContent, _jsonOptions);
+            return JsonSerializer.Deserialize<ProxyHost>(responseContent, _jsonOptions)!;
         }
 
         /// <inheritdoc />
@@ -157,7 +157,7 @@ namespace NginxProxyManager.SDK.Services
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProxyHost>(content, _jsonOptions);
+            return JsonSerializer.Deserialize<ProxyHost>(content, _jsonOptions)!;
         }
 
         /// <inheritdoc />
@@ -167,7 +167,7 @@ namespace NginxProxyManager.SDK.Services
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProxyHost[]>(content, _jsonOptions);
+            return JsonSerializer.Deserialize<ProxyHost[]>(content, _jsonOptions)!;
         }
 
         /// <inheritdoc />
@@ -177,7 +177,7 @@ namespace NginxProxyManager.SDK.Services
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProxyHost[]>(content, _jsonOptions);
+            return JsonSerializer.Deserialize<ProxyHost[]>(content, _jsonOptions)!;
         }
 
         /// <inheritdoc />
@@ -190,7 +190,7 @@ namespace NginxProxyManager.SDK.Services
             response.EnsureSuccessStatusCode();
 
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProxyHost>(responseContent, _jsonOptions);
+            return JsonSerializer.Deserialize<ProxyHost>(responseContent, _jsonOptions)!;
         }
     }
 } 

--- a/Services/RedirectionService.cs
+++ b/Services/RedirectionService.cs
@@ -93,7 +93,7 @@ namespace NginxProxyManager.SDK.Services
         }
 
         /// <inheritdoc />
-        public async Task<OperationResult<RedirectionHost[]>> GetRedirectionHostsAsync(string expand, CancellationToken cancellationToken)
+        public async Task<OperationResult<RedirectionHost[]>> GetRedirectionHostsAsync(string? expand, CancellationToken cancellationToken)
         {
             try
             {

--- a/Services/ServerErrorService.cs
+++ b/Services/ServerErrorService.cs
@@ -49,7 +49,7 @@ namespace NginxProxyManager.SDK.Services
         {
             using var request = CreateRequest(HttpMethod.Delete, serverErrorId.ToString());
             await SendAsync<object>(request, cancellationToken);
-            return new OperationResult<object>(null);
+            return new OperationResult<object>((object?)null);
         }
 
         /// <inheritdoc/>
@@ -57,7 +57,7 @@ namespace NginxProxyManager.SDK.Services
         {
             using var request = CreateRequest(HttpMethod.Delete, $"host/{hostId}");
             await SendAsync<object>(request, cancellationToken);
-            return new OperationResult<object>(null);
+            return new OperationResult<object>((object?)null);
         }
     }
 } 

--- a/Services/StreamService.cs
+++ b/Services/StreamService.cs
@@ -21,7 +21,7 @@ namespace NginxProxyManager.SDK.Services
         }
 
         /// <inheritdoc/>
-        public async Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetStreamsAsync(string expand = null, CancellationToken cancellationToken = default)
+        public async Task<OperationResult<NginxProxyManager.SDK.Models.Streams.Stream[]>> GetStreamsAsync(string? expand = null, CancellationToken cancellationToken = default)
         {
             var path = expand != null ? $"?expand={expand}" : "";
             using var request = CreateRequest(HttpMethod.Get, path);
@@ -58,7 +58,7 @@ namespace NginxProxyManager.SDK.Services
         {
             using var request = CreateRequest(HttpMethod.Delete, streamId.ToString());
             await SendAsync<object>(request, cancellationToken);
-            return new OperationResult<object>(null);
+            return new OperationResult<object>((object?)null);
         }
 
         /// <inheritdoc/>
@@ -66,7 +66,7 @@ namespace NginxProxyManager.SDK.Services
         {
             using var request = CreateRequest(HttpMethod.Post, $"{streamId}/enable");
             await SendAsync<object>(request, cancellationToken);
-            return new OperationResult<object>(null);
+            return new OperationResult<object>((object?)null);
         }
 
         /// <inheritdoc/>
@@ -74,7 +74,7 @@ namespace NginxProxyManager.SDK.Services
         {
             using var request = CreateRequest(HttpMethod.Post, $"{streamId}/disable");
             await SendAsync<object>(request, cancellationToken);
-            return new OperationResult<object>(null);
+            return new OperationResult<object>((object?)null);
         }
     }
 } 


### PR DESCRIPTION
Reduces nullable warning debt to zero warnings on a clean Release solution build.

Key changes:
- documents serializer-populated DTO members with non-null defaults
- marks truly optional result/error/config members nullable
- removes null default parameter warnings on optional expand arguments
- adds deserialization null guards/null-forgiving returns where appropriate
- fixes interface member hiding warnings with explicit `new`

Gates run locally:
- `dotnet build NginxProxyManager.SDK.slnx --configuration Release /clp:Summary` ✅ (0 warnings, 0 errors)
- `dotnet test NginxProxyManager.SDK.slnx --no-build --configuration Release --verbosity normal` ✅ (3 passed)
- `dotnet pack NginxProxyManager.SDK.slnx --no-build --configuration Release --output ./artifacts` ✅

Fixes #9.